### PR TITLE
Support TLSv1.2+

### DIFF
--- a/src/osdep/unix/ssl_unix.c
+++ b/src/osdep/unix/ssl_unix.c
@@ -220,7 +220,11 @@ static char *ssl_start_work (SSLSTREAM *stream,char *host,unsigned long flags)
   if (ssl_last_error) fs_give ((void **) &ssl_last_error);
   ssl_last_host = host;
   if (!(stream->context = SSL_CTX_new ((flags & NET_TLSCLIENT) ?
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
+				       TLS_client_method () :
+#else
 				       TLSv1_client_method () :
+#endif
 				       SSLv23_client_method ())))
     return "SSL context failed";
   SSL_CTX_set_options (stream->context,0);
@@ -715,7 +719,11 @@ void ssl_server_init (char *server)
   }
 				/* create context */
   if (!(stream->context = SSL_CTX_new (start_tls ?
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
+				       TLS_server_method () :
+#else
 				       TLSv1_server_method () :
+#endif
 				       SSLv23_server_method ())))
     syslog (LOG_ALERT,"Unable to create SSL context, host=%.80s",
 	    tcp_clienthost ());


### PR DESCRIPTION
The patched sources of uw-imap 2007f support building against OpenSSL 1.1.0 or later.

However, TLSv1_client_method() and TLSv1_server_method() restricts uw-imap to TLSv1.0.

These APIs, along with explicitly versioned APIs like `TLSv1_1_*_method()` and `TLSv1_2_*_method()` are deprecated in OpenSSL 1.1.0 or later. The replacements are unversioned API functions: `TLS_client_method()` and `TLS_server_method()` which support TLS version autonegotiation.

This allows the PHP IMAP extension to work with IMAP servers that enforce TLSv1.2 or higher.

Fixes: https://bugs.php.net/bug.php?id=76928